### PR TITLE
Force integrated terminal to PowerShell in workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "Lua.diagnostics.globals": ["playdate", "import"],
   "Lua.runtime.nonstandardSymbol": ["+=", "-=", "*=", "/="],
   "Lua.workspace.library": ["$PLAYDATE_SDK_PATH/CoreLibs"],
-  "Lua.workspace.preloadFileSize": 1000
+  "Lua.workspace.preloadFileSize": 1000,
+  "terminal.integrated.defaultProfile.windows": "PowerShell"
 }


### PR DESCRIPTION
I had [the same issue as SenseiRAM](https://github.com/Whitebrim/VSCode-PlaydateTemplate/issues/7) when using the build & run script because my default terminal is cmd in VSCode. This change forces the terminal to be PowerShell only for this workspace, avoiding unclear build failure errors :)