### PR TITLE
Add Linux build/run script and .vscode dir

### DIFF
--- a/.vscode-linux/extensions.json
+++ b/.vscode-linux/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "sumneko.lua",
+        "jep-a.lua-plus"
+    ]
+}

--- a/.vscode-linux/settings.json
+++ b/.vscode-linux/settings.json
@@ -1,0 +1,8 @@
+{
+  "Lua.runtime.version": "Lua 5.4",
+  "Lua.diagnostics.disable": ["undefined-global", "lowercase-global"],
+  "Lua.diagnostics.globals": ["playdate", "import"],
+  "Lua.runtime.nonstandardSymbol": ["+=", "-=", "*=", "/="],
+  "Lua.workspace.library": ["$PLAYDATE_SDK_PATH/CoreLibs"],
+  "Lua.workspace.preloadFileSize": 1000
+}

--- a/.vscode-linux/tasks.json
+++ b/.vscode-linux/tasks.json
@@ -1,0 +1,64 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+	  {
+		"label": "Invoke Build and Run script",
+		"type": "shell",
+		"command": "${workspaceFolder}/build_and_run.sh",
+		"args": [
+			"build"
+		],
+		"presentation": {
+		  "showReuseMessage": false,
+		  "reveal": "always",
+		  "panel": "shared"
+		}
+	  },
+	  {
+		"label": "Invoke Run script",
+		"type": "shell",
+		"command": "${workspaceFolder}/build_and_run.sh",
+		"args": [
+			"run"
+		],
+		"presentation": {
+		  "showReuseMessage": false,
+		  "reveal": "always",
+		  "panel": "shared"
+		}
+	  },
+	  {
+		"label": "Build and Run (Simulator)",
+		"dependsOn": ["Invoke Build and Run script"],
+		"dependsOrder": "sequence",
+		"presentation": {
+		  "showReuseMessage": false,
+		  "reveal": "always",
+		  "panel": "shared"
+		},
+		"problemMatcher": [],
+		"group": {
+		  "kind": "build",
+		  "isDefault": true
+		}
+	  },
+	  {
+		"label": "Run (Simulator)",
+		"dependsOn": ["Invoke Run script"],
+		"dependsOrder": "sequence",
+		"presentation": {
+		  "showReuseMessage": false,
+		  "reveal": "always",
+		  "panel": "shared"
+		},
+		"problemMatcher": [],
+		"group": {
+		  "kind": "test",
+		  "isDefault": true
+		}
+	  }
+	]
+  }
+  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://media.giphy.com/media/QhNgpDotBASjWj7asJ/giphy.gif" width="800" height="480" />
 
-# Installation:  
+# Installation (Windows):  
 0. **Unlock** `Build and Run (Simulator).ps1` file if it's locked: open properties and click unlock in the bottom of the window.  
 0. If you've installed Playdate SDK to the default path (Documents folder) then just **run** `ADD_ENV_VARIABLE.cmd` to add env variables:  
     * PLAYDATE_SDK_PATH to Playdate SDK
@@ -19,5 +19,22 @@
     * Change keybind for `Tasks: Run Build Task` (I've changed to **F5**)  
 0. Your can find your `main.lua` file inside `source` folder. Press your "Run Build Task" button, you should see "Template" text in playdate simulator.  
 0. Feel free to delete `dvd.lua` and all dvd-related lines from `main.lua` (marked `-- DEMOO`)
-0. ## ⚠️ Don't forget to change your unique project info in `source/pdxinfo`: "bundleID", "name", "author", "description". Read more about pdxinfo [here](https://sdk.play.date/Inside%20Playdate.html#pdxinfo).  
-    It's critical to change your game bundleID, so there will be no collisions with other games, installed via sideload.
+
+# Installation (Linux):
+0. If it's not already executable, navigate to this directory and make `build_and_run.sh` executable by running the following command:
+    ```
+    chmod +x build_and_run.sh
+    ```
+0. Move/rename the default `.vscode` directory (for Windows) to something else, or delete it:
+    ```
+    mv .vscode .vscode-windows
+    ```
+0. Move/rename the Linux-specific `.vscode` directory to be default
+    ```
+    mv .vscode-linux .vscode
+    ```
+0. Add `PLAYDATE_SDK_PATH` to your `.bashrc`/`.zshrc` or equivalent, and source it; check it with: `env | grep -i playdate`
+0. Launch/relaunch VSCode - if prompted to install extensions, click Yes.
+0. If desired, change the default key sequence for Build/Run as described in the Windows instructions above
+
+## ⚠️ Don't forget to change your unique project info in `source/pdxinfo`: "bundleID", "name", "author", "description". Read more about pdxinfo [here](https://sdk.play.date/Inside%20Playdate.html#pdxinfo). It's critical to change your game bundleID, so there will be no collisions with other games, installed via sideload.

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -4,6 +4,7 @@
 if [[ -z $NOCOLOR && -n $(command -v tput) ]]; then
     RED=$(tput setaf 1)
     CYN=$(tput setaf 6)
+    YEL=$(tput setaf 3)
     RST=$(tput sgr0)
 fi
 
@@ -11,8 +12,8 @@ function display_help() {
     printf "%s\n\n" "${0} build|run|-h|--help|"
     printf "%-16s\n" "build: Builds the project and runs the Simulator"
     printf "%-16s\n" "run  : Skips building the project and runs the Simulator"
-    printf "\n\n"
-    printf "%s" "Set NOCOLOR=1 to disable terminal coloring"
+    printf "\n"
+    printf "%s\n\n" "Set NOCOLOR=1 to disable terminal coloring"
     exit 0
 }
 
@@ -39,8 +40,22 @@ PDX_PATH="${BUILD_DIR}/$(basename $(pwd)).pdx"
 function log() {
     printf "%s\n" "${CYN}>> $1${RST}"
 }
+function log_warn() {
+    printf "%s\n" "${YEL}>! $1${RST}"
+}
 function log_err() {
     printf "%s\n  >> %s\n" "${RED}!! ERROR !!" "$1${RST}"
+}
+
+function check_pdxinfo() {
+    if [[ -f ./source/pdxinfo ]]; then
+        if grep "com.organization.package" ./source/pdxinfo 2>&1 >/dev/null; then
+            log_warn "PDXINFO NOTICE:"
+            log_warn "Don't forget to change your unique project info in 'source/pdxinfo': 'bundleID', 'name', 'author', 'description'."
+            log_warn "It's critical to change your game bundleID, so there will be no collisions with other games, installed via sideload."
+            log_warn "Read more about pdxinfo here: https://sdk.play.date/Inside%20Playdate.html#pdxinfo"
+        fi
+    fi
 }
 
 function chk_err() {
@@ -116,6 +131,7 @@ if [[ $BUILD == 1 ]]; then
     log "Attempting a build and run of PDX..."
     make_build_dir
     clean_build_dir
+    check_pdxinfo
     build_pdx
     check_close_sim
     run_pdx

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Check for color by variable and tput command
+if [[ -z $NOCOLOR && -n $(command -v tput) ]]; then
+    RED=$(tput setaf 1)
+    CYN=$(tput setaf 6)
+    RST=$(tput sgr0)
+fi
+
+function display_help() {
+    printf "%s\n\n" "${0} build|run|-h|--help|"
+    printf "%-16s\n" "build: Builds the project and runs the Simulator"
+    printf "%-16s\n" "run  : Skips building the project and runs the Simulator"
+    printf "\n\n"
+    printf "%s" "Set NOCOLOR=1 to disable terminal coloring"
+    exit 0
+}
+
+# We don't need fancy flags/operators for two commands
+case $1 in
+    "build")
+        BUILD=1
+        ;;
+    "run")
+        BUILD=0
+        ;;
+    *)
+        display_help
+        exit 1
+        ;;
+esac
+
+# Set some paths
+BUILD_DIR="./builds"
+SOURCE_DIR="./source"
+PDX_PATH="${BUILD_DIR}/$(basename $(pwd)).pdx"
+
+# Logging functions
+function log() {
+    printf "%s\n" "${CYN}>> $1${RST}"
+}
+function log_err() {
+    printf "%s\n  >> %s\n" "${RED}!! ERROR !!" "$1${RST}"
+}
+
+function chk_err() {
+    # Check for errors in last process and bail if needed
+    if [[ $? > 0 ]]; then
+        log_err "There was an issue with the previous command; exiting!"
+        exit 1
+    fi
+}
+
+function check_close_sim() {
+    # Check if we have 'pidof'
+    PIDOF=$(command -v pidof2)
+
+    # Prefer 'pidof'; use ps if not
+    if [[ -n $PIDOF ]]; then
+        SIMPID=$($PIDOF "PlaydateSimulator")
+        if [[ -n $SIMPID ]]; then
+            log "Found existing Simulator, closing..."
+            kill -9 $SIMPID
+            chk_err
+        fi
+    else
+        SIMPID=$(ps aux | grep PlaydateSimulator | grep -v grep | awk '{print $2}')
+        if [[ -n $SIMPID ]]; then
+            log "Found existing Simulator, closing..."
+            kill -9 $SIMPID
+            chk_err
+        fi
+    fi
+}
+
+# Create build dir
+function make_build_dir() {
+    if [[ ! -d "${BUILD_DIR}" ]]; then
+        log "Creating build directory..."
+        mkdir -p "${BUILD_DIR}"
+        chk_err
+    fi
+}
+
+# Clean build dir
+function clean_build_dir() {
+    if [[ -d "${BUILD_DIR}" ]]; then
+        log "Cleaning build directory..."
+        rm -rfv "${BUILD_DIR}/*"
+        chk_err
+    fi
+}
+
+# Compile the PDX
+function build_pdx() {
+    if [[ $BUILD == 1 ]]; then
+        log "Building PDX with 'pdc'..."
+        $PLAYDATE_SDK_PATH/bin/pdc -sdkpath "${PLAYDATE_SDK_PATH}" "${SOURCE_DIR}" "${PDX_PATH}"
+        chk_err
+    fi
+}
+
+# Run the PDX with Simulator
+function run_pdx() {
+    if [[ -d "${PDX_PATH}" ]]; then
+        log "Running PDX with Simulator..."
+        $PLAYDATE_SDK_PATH/bin/PlaydateSimulator "${PDX_PATH}"
+    else
+        log_err "PDX doesn't exist! Please 'build' the project first!"
+    fi
+}
+
+
+#### MAIN SCRIPT ####
+if [[ $BUILD == 1 ]]; then
+    log "Attempting a build and run of PDX..."
+    make_build_dir
+    clean_build_dir
+    build_pdx
+    check_close_sim
+    run_pdx
+else
+    log "Attempting to run PDX: ${PDX_PATH}..."
+    check_close_sim
+    run_pdx
+fi
+


### PR DESCRIPTION
Hello! If you're interested, I have created a Linux-based build/run script and `.vscode-directory` directory for easier non-Windows setup. Since this was originally Windows-first this strives to not step on any toes; setting up for Linux requires a simple rename/delete of the existing `.vscode` folder and replacing it with `.vscode-linux`. 

The script features some of the following:

* Based on the PS1 script, handles building and running, as well as locating a running Simulator and closing it before launch
* Colorized logging messages, controllable with `NOCOLOR` env var
* Warning dump if default package name found in `source/pdxinfo`

I've also updated the README to include instructions on setup. If you're not interested in this PR, feel free to close it and I will continue to maintain it on my fork/branch.

![playdate_linux_build](https://github.com/Whitebrim/VSCode-PlaydateTemplate/assets/1794794/bbb0767a-2f88-4116-82d4-76dba1f74728)

![playdate_linux_vscode](https://github.com/Whitebrim/VSCode-PlaydateTemplate/assets/1794794/a6ad5a37-741f-4a40-9b88-ab08a0f91b83)


