### PR TITLE
Move powershell config from settings to tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,4 @@
   "Lua.runtime.nonstandardSymbol": ["+=", "-=", "*=", "/=", "//=", "%=", "<<=", ">>=", "&=", "|=", "^="],
   "Lua.workspace.library": ["$PLAYDATE_SDK_PATH/CoreLibs"],
   "Lua.workspace.preloadFileSize": 1000,
-  "terminal.integrated.defaultProfile.windows": "PowerShell"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,12 @@
 				"'${workspaceFolder}\\source'",
 				"-name",
 				"'${workspaceFolderBasename}'"
-			]
+			],
+			"options": {
+				"shell": {
+					"executable": "powershell.exe"
+				}
+			}
 		},
 		"linux": {
 			"command": "${workspaceFolder}/build_and_run.sh",
@@ -44,7 +49,12 @@
 				"-name",
 				"'${workspaceFolderBasename}'",
 				"-dontbuild"
-			]
+			],
+			"options": {
+				"shell": {
+					"executable": "powershell.exe"
+				}
+			}
 		},
 		"linux": {
 			"command": "${workspaceFolder}/build_and_run.sh",


### PR DESCRIPTION
This allows the user to have their own defined shell (e.g. git bash) but still use powershell for the script.