### PR TITLE
Reorder the execution in the build and run script

### DIFF
--- a/Build and Run (Simulator).ps1
+++ b/Build and Run (Simulator).ps1
@@ -4,25 +4,6 @@
     [string]$name = (Get-Item -Path .).BaseName,
     [switch]$dontbuild = $false
  )
-$pdx = Join-Path -Path "$build" -ChildPath "$name.pdx"
-
-# Create build folder if not present
-if (!$dontbuild)
-{
-    New-Item -ItemType Directory -Force -Path "$build"
-}
-
-# Clean build folder
-if (!$dontbuild)
-{
-    Remove-Item "$build\*" -Recurse -Force 
-}
-
-# Build
-if (!$dontbuild)
-{
-    pdc -sdkpath "$Env:PLAYDATE_SDK_PATH" "$source" "$pdx"
-}
 
 # Close Simulator
 $sim = Get-Process "PlaydateSimulator" -ErrorAction SilentlyContinue
@@ -41,6 +22,26 @@ if ($sim)
             $sim | Stop-Process -Force
         }
     }
+}
+
+$pdx = Join-Path -Path "$build" -ChildPath "$name.pdx"
+
+# Create build folder if not present
+if (!$dontbuild)
+{
+    New-Item -ItemType Directory -Force -Path "$build"
+}
+
+# Clean build folder
+if (!$dontbuild)
+{
+    Remove-Item "$build\*" -Recurse -Force 
+}
+
+# Build
+if (!$dontbuild)
+{
+    pdc -sdkpath "$Env:PLAYDATE_SDK_PATH" "$source" "$pdx"
 }
 
 # Run (Simulator)


### PR DESCRIPTION
We have to first close the simulator before re-building and running. Otherwise, we might encounter error when e.g. playing music from the simulator when running this script.