### PR TITLE
Remove undefined-globals from diagnostics disable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "Lua.runtime.version": "Lua 5.4",
-  "Lua.diagnostics.disable": ["undefined-global", "lowercase-global"],
-  "Lua.diagnostics.globals": ["playdate", "import"],
+  "Lua.diagnostics.disable": ["lowercase-global"],
+  "Lua.diagnostics.globals": ["playdate", "import", "json"],
   "Lua.runtime.nonstandardSymbol": ["+=", "-=", "*=", "/=", "//=", "%=", "<<=", ">>=", "&=", "|=", "^="],
   "Lua.workspace.library": ["$PLAYDATE_SDK_PATH/CoreLibs"],
   "Lua.workspace.preloadFileSize": 1000,

--- a/Source/dvd.lua
+++ b/Source/dvd.lua
@@ -3,6 +3,7 @@ import "CoreLibs/object"
 
 local gfx <const> = playdate.graphics
 
+dvd={}
 class("dvd").extends()
 
 function dvd:init(xspeed, yspeed)


### PR DESCRIPTION
cons

every time you define a class, you have to add an extra line on top of the class so there is a global object defined
thats because the 'class' method is a playdate thing and creates the object in runtime only, so lua language server is unaware of the object itself

pros

development is much faster because any typos, bad replacements, code copying and pasting and etc can be spotted at programming time instead of runtime, saving a billion of resets and making code much more reliable 

If anyone needs to apply this to their project, a replace macro for VSCode:

Search:
`class\("(.*)"\)`

Replace:
```
$1={}
class("$1")
```